### PR TITLE
chore: print deprecation warning when running from @master

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eux
 
+echo '::warning::The version nrkno/yaml-schema-validator-github-action@master is a deprecated version of this action which contains a security vulnerability. Please update to nrkno/yaml-schema-validator-github-action@v4 and check out the repository for more information.'
+
 strict=''
 schema=${INPUT_SCHEMA:-$1}
 target=${INPUT_TARGET:-$2}


### PR DESCRIPTION
It is not very visible, but at least it shows some sort of warning at all. This is from the "Summary" of the run on the "Actions" page in a repository.
![image](https://user-images.githubusercontent.com/952936/153235297-872abcae-38c5-4de0-bf94-2f01b6229ddc.png)
